### PR TITLE
Allocation free dictionary lookup

### DIFF
--- a/src/Morfologik.Stemming/BufferUtils.cs
+++ b/src/Morfologik.Stemming/BufferUtils.cs
@@ -125,15 +125,7 @@ namespace Morfologik.Stemming
             //Debug.Assert( decoder.malformedInputAction() == CodingErrorAction.REPORT;
 
             chars = ClearAndEnsureCapacity(chars, decoder.GetMaxCharCount(bytes.Remaining));
-
-            bytes.Mark();
-
-            byte[] b = ToArray(bytes);
-            string decoded = decoder.GetString(b);
-            chars.Put(decoded);
-
-            chars.Flip();
-            bytes.Reset();
+            chars.Limit = decoder.GetChars(bytes.Array, bytes.Position, bytes.Remaining, chars.Array, chars.Position);
 
             return chars;
         }
@@ -146,15 +138,7 @@ namespace Morfologik.Stemming
             //assert encoder.malformedInputAction() == CodingErrorAction.REPORT;
 
             bytes = ClearAndEnsureCapacity(bytes, encoder.GetMaxByteCount(chars.Remaining));
-
-            chars.Mark();
-
-            var temp = chars.ToString();
-            byte[] b = encoder.GetBytes(temp);
-            bytes.Put(b);
-
-            bytes.Flip();
-            chars.Reset();
+            bytes.Limit = encoder.GetBytes(chars.Array, chars.Position, chars.Remaining, bytes.Array, bytes.Position);
 
             return bytes;
         }

--- a/src/Morfologik.Stemming/DictionaryLookup.cs
+++ b/src/Morfologik.Stemming/DictionaryLookup.cs
@@ -66,6 +66,16 @@ namespace Morfologik.Stemming
         private ByteBuffer byteBuffer = ByteBuffer.Allocate(0);
 
         /// <summary>
+        /// Internal reusable buffer for <see cref="byteBuffer"/> slicing.
+        /// </summary>
+        private ByteBuffer byteBufferSlice = ByteBuffer.Allocate(0);
+
+        /// <summary>
+        /// Internal reusable buffer for encoding words into char arrays.
+        /// </summary>
+        private CharBuffer wordBuffer = CharBuffer.Allocate(0);
+
+        /// <summary>
         /// Internal reusable buffer for encoding words into byte arrays using
         /// <see cref="encoder"/>.
         /// </summary>
@@ -224,11 +234,16 @@ namespace Morfologik.Stemming
                         }
 
                         /*
+                         * Slice byteBuffer by separator position
+                         */
+                        byteBufferSlice = BufferUtils.ClearAndEnsureCapacity(byteBufferSlice, sepPos);
+                        byteBufferSlice.Put(ba, 0, sepPos);
+                        byteBufferSlice.Flip();
+
+                        /*
                          * Decode the stem into stem buffer.
                          */
-                        wordData.stemBuffer = sequenceEncoder.Decode(wordData.stemBuffer,
-                                                                 byteBuffer,
-                                                                 ByteBuffer.Wrap(ba, 0, sepPos));
+                        wordData.stemBuffer = sequenceEncoder.Decode(wordData.stemBuffer, byteBuffer, byteBufferSlice);
 
                         // Skip separator character.
                         sepPos++;
@@ -266,144 +281,11 @@ namespace Morfologik.Stemming
         /// </summary>
         public IList<WordData> Lookup(char[] word)
         {
-            byte separator = dictionaryMetadata.Separator;
-#pragma warning disable 612, 618
-            int prefixBytes = sequenceEncoder.PrefixBytes;
-#pragma warning restore 612, 618
+            wordBuffer = BufferUtils.ClearAndEnsureCapacity(wordBuffer, word.Length);
+            wordBuffer.Put(word);
+            wordBuffer.Flip();
 
-            if (dictionaryMetadata.InputConversionPairs.Any())
-            {
-                word = ApplyReplacements(word, dictionaryMetadata.InputConversionPairs);
-            }
-
-            // Reset the output list to zero length.
-            formsList.Wrap(forms, 0, 0);
-
-            // Encode word characters into bytes in the same encoding as the FSA's.
-            charBuffer = BufferUtils.ClearAndEnsureCapacity(charBuffer, word.Length);
-            for (int i = 0; i < word.Length; i++)
-            {
-                char chr = word[i];
-                if (chr == separatorChar)
-                {
-                    // No valid input can contain the separator.
-                    return formsList;
-                }
-                charBuffer.Put(chr);
-            }
-            charBuffer.Flip();
-            try
-            {
-                byteBuffer = BufferUtils.CharsToBytes(encoder, charBuffer, byteBuffer);
-            }
-            catch (UnmappableInputException)
-            {
-                // This should be a rare occurrence, but if it happens it means there is no way
-                // the dictionary can contain the input word.
-                return formsList;
-            }
-
-            // Try to find a partial match in the dictionary.
-            MatchResult match = matcher.Match(matchResult, byteBuffer
-                .Array, 0, byteBuffer.Remaining, rootNode);
-
-            if (match.Kind == MatchResult.SequenceIsAPrefix)
-            {
-                /*
-                 * The entire sequence exists in the dictionary. A separator should
-                 * be the next symbol.
-                 */
-                int arc = fsa.GetArc(match.Node, separator);
-
-                /*
-                 * The situation when the arc points to a final node should NEVER
-                 * happen. After all, we want the word to have SOME base form.
-                 */
-                if (arc != 0 && !fsa.IsArcFinal(arc))
-                {
-                    // There is such a word in the dictionary. Return its base forms.
-                    int formsCount = 0;
-
-                    finalStatesIterator.RestartFrom(fsa.GetEndNode(arc));
-                    while (finalStatesIterator.MoveNext())
-                    {
-                        ByteBuffer bb = finalStatesIterator.Current;
-                        byte[] ba = bb.Array;
-                        int bbSize = bb.Remaining;
-
-                        if (formsCount >= forms.Length)
-                        {
-                            //forms = Arrays.CopyOf(forms, forms.Length + EXPAND_SIZE);
-                            Array.Resize(ref forms, forms.Length + ExpandSize);
-                            for (int k = 0; k < forms.Length; k++)
-                            {
-                                if (forms[k] == null)
-                                    forms[k] = new WordData(decoder);
-                            }
-                        }
-
-                        /*
-                         * Now, expand the prefix/ suffix 'compression' and store
-                         * the base form.
-                         */
-                        WordData wordData = forms[formsCount++];
-                        if (!dictionaryMetadata.OutputConversionPairs.Any())
-                        {
-                            wordData.Update(byteBuffer, word);
-                        }
-                        else
-                        {
-                            wordData.Update(byteBuffer, ApplyReplacements(word, dictionaryMetadata.OutputConversionPairs));
-                        }
-
-                        /*
-                         * Find the separator byte's position splitting the inflection instructions
-                         * from the tag.
-                         */
-                        Debug.Assert(prefixBytes <= bbSize, sequenceEncoder.GetType() + " >? " + bbSize);
-                        int sepPos;
-                        for (sepPos = prefixBytes; sepPos < bbSize; sepPos++)
-                        {
-                            if (ba[sepPos] == separator)
-                            {
-                                break;
-                            }
-                        }
-
-                        /*
-                         * Decode the stem into stem buffer.
-                         */
-                        wordData.stemBuffer = sequenceEncoder.Decode(wordData.stemBuffer,
-                                                                 byteBuffer,
-                                                                 ByteBuffer.Wrap(ba, 0, sepPos));
-
-                        // Skip separator character.
-                        sepPos++;
-
-                        /*
-                         * Decode the tag data.
-                         */
-                        int tagSize = bbSize - sepPos;
-                        if (tagSize > 0)
-                        {
-                            wordData.tagBuffer = BufferUtils.ClearAndEnsureCapacity(wordData.tagBuffer, tagSize);
-                            wordData.tagBuffer.Put(ba, sepPos, tagSize);
-                            wordData.tagBuffer.Flip();
-                        }
-                    }
-
-                    formsList.Wrap(forms, 0, formsCount);
-                }
-            }
-            else
-            {
-                /*
-                 * this case is somewhat confusing: we should have hit the separator
-                 * first... I don't really know how to deal with it at the time
-                 * being.
-                 */
-            }
-            return formsList;
+            return Lookup(wordBuffer);
         }
 
         /// <summary>
@@ -413,144 +295,16 @@ namespace Morfologik.Stemming
         /// </summary>
         public IList<WordData> Lookup(StringBuilder word)
         {
-            byte separator = dictionaryMetadata.Separator;
-#pragma warning disable 612, 618
-            int prefixBytes = sequenceEncoder.PrefixBytes;
-#pragma warning restore 612, 618
+            wordBuffer = BufferUtils.ClearAndEnsureCapacity(wordBuffer, word.Length);
 
-            if (dictionaryMetadata.InputConversionPairs.Any())
+            for (var i = 0; i < word.Length; i++)
             {
-                word = ApplyReplacements(word, dictionaryMetadata.InputConversionPairs);
+                wordBuffer.Put(word[i]);
             }
 
-            // Reset the output list to zero length.
-            formsList.Wrap(forms, 0, 0);
+            wordBuffer.Flip();
 
-            // Encode word characters into bytes in the same encoding as the FSA's.
-            charBuffer = BufferUtils.ClearAndEnsureCapacity(charBuffer, word.Length);
-            for (int i = 0; i < word.Length; i++)
-            {
-                char chr = word[i];
-                if (chr == separatorChar)
-                {
-                    // No valid input can contain the separator.
-                    return formsList;
-                }
-                charBuffer.Put(chr);
-            }
-            charBuffer.Flip();
-            try
-            {
-                byteBuffer = BufferUtils.CharsToBytes(encoder, charBuffer, byteBuffer);
-            }
-            catch (UnmappableInputException)
-            {
-                // This should be a rare occurrence, but if it happens it means there is no way
-                // the dictionary can contain the input word.
-                return formsList;
-            }
-
-            // Try to find a partial match in the dictionary.
-            MatchResult match = matcher.Match(matchResult, byteBuffer
-                .Array, 0, byteBuffer.Remaining, rootNode);
-
-            if (match.Kind == MatchResult.SequenceIsAPrefix)
-            {
-                /*
-                 * The entire sequence exists in the dictionary. A separator should
-                 * be the next symbol.
-                 */
-                int arc = fsa.GetArc(match.Node, separator);
-
-                /*
-                 * The situation when the arc points to a final node should NEVER
-                 * happen. After all, we want the word to have SOME base form.
-                 */
-                if (arc != 0 && !fsa.IsArcFinal(arc))
-                {
-                    // There is such a word in the dictionary. Return its base forms.
-                    int formsCount = 0;
-
-                    finalStatesIterator.RestartFrom(fsa.GetEndNode(arc));
-                    while (finalStatesIterator.MoveNext())
-                    {
-                        ByteBuffer bb = finalStatesIterator.Current;
-                        byte[] ba = bb.Array;
-                        int bbSize = bb.Remaining;
-
-                        if (formsCount >= forms.Length)
-                        {
-                            //forms = Arrays.CopyOf(forms, forms.Length + EXPAND_SIZE);
-                            Array.Resize(ref forms, forms.Length + ExpandSize);
-                            for (int k = 0; k < forms.Length; k++)
-                            {
-                                if (forms[k] == null)
-                                    forms[k] = new WordData(decoder);
-                            }
-                        }
-
-                        /*
-                         * Now, expand the prefix/ suffix 'compression' and store
-                         * the base form.
-                         */
-                        WordData wordData = forms[formsCount++];
-                        if (!dictionaryMetadata.OutputConversionPairs.Any())
-                        {
-                            wordData.Update(byteBuffer, word);
-                        }
-                        else
-                        {
-                            wordData.Update(byteBuffer, ApplyReplacements(word, dictionaryMetadata.OutputConversionPairs));
-                        }
-
-                        /*
-                         * Find the separator byte's position splitting the inflection instructions
-                         * from the tag.
-                         */
-                        Debug.Assert(prefixBytes <= bbSize, sequenceEncoder.GetType() + " >? " + bbSize);
-                        int sepPos;
-                        for (sepPos = prefixBytes; sepPos < bbSize; sepPos++)
-                        {
-                            if (ba[sepPos] == separator)
-                            {
-                                break;
-                            }
-                        }
-
-                        /*
-                         * Decode the stem into stem buffer.
-                         */
-                        wordData.stemBuffer = sequenceEncoder.Decode(wordData.stemBuffer,
-                                                                 byteBuffer,
-                                                                 ByteBuffer.Wrap(ba, 0, sepPos));
-
-                        // Skip separator character.
-                        sepPos++;
-
-                        /*
-                         * Decode the tag data.
-                         */
-                        int tagSize = bbSize - sepPos;
-                        if (tagSize > 0)
-                        {
-                            wordData.tagBuffer = BufferUtils.ClearAndEnsureCapacity(wordData.tagBuffer, tagSize);
-                            wordData.tagBuffer.Put(ba, sepPos, tagSize);
-                            wordData.tagBuffer.Flip();
-                        }
-                    }
-
-                    formsList.Wrap(forms, 0, formsCount);
-                }
-            }
-            else
-            {
-                /*
-                 * this case is somewhat confusing: we should have hit the separator
-                 * first... I don't really know how to deal with it at the time
-                 * being.
-                 */
-            }
-            return formsList;
+            return Lookup(wordBuffer);
         }
 
         /// <summary>
@@ -560,144 +314,11 @@ namespace Morfologik.Stemming
         /// </summary>
         public IList<WordData> Lookup(string word)
         {
-            byte separator = dictionaryMetadata.Separator;
-#pragma warning disable 612, 618
-            int prefixBytes = sequenceEncoder.PrefixBytes;
-#pragma warning restore 612, 618
+            wordBuffer = BufferUtils.ClearAndEnsureCapacity(wordBuffer, word.Length);
+            wordBuffer.Put(word);
+            wordBuffer.Flip();
 
-            if (dictionaryMetadata.InputConversionPairs.Any())
-            {
-                word = ApplyReplacements(word, dictionaryMetadata.InputConversionPairs);
-            }
-
-            // Reset the output list to zero length.
-            formsList.Wrap(forms, 0, 0);
-
-            // Encode word characters into bytes in the same encoding as the FSA's.
-            charBuffer = BufferUtils.ClearAndEnsureCapacity(charBuffer, word.Length);
-            for (int i = 0; i < word.Length; i++)
-            {
-                char chr = word[i];
-                if (chr == separatorChar)
-                {
-                    // No valid input can contain the separator.
-                    return formsList;
-                }
-                charBuffer.Put(chr);
-            }
-            charBuffer.Flip();
-            try
-            {
-                byteBuffer = BufferUtils.CharsToBytes(encoder, charBuffer, byteBuffer);
-            }
-            catch (UnmappableInputException)
-            {
-                // This should be a rare occurrence, but if it happens it means there is no way
-                // the dictionary can contain the input word.
-                return formsList;
-            }
-
-            // Try to find a partial match in the dictionary.
-            MatchResult match = matcher.Match(matchResult, byteBuffer
-                .Array, 0, byteBuffer.Remaining, rootNode);
-
-            if (match.Kind == MatchResult.SequenceIsAPrefix)
-            {
-                /*
-                 * The entire sequence exists in the dictionary. A separator should
-                 * be the next symbol.
-                 */
-                int arc = fsa.GetArc(match.Node, separator);
-
-                /*
-                 * The situation when the arc points to a final node should NEVER
-                 * happen. After all, we want the word to have SOME base form.
-                 */
-                if (arc != 0 && !fsa.IsArcFinal(arc))
-                {
-                    // There is such a word in the dictionary. Return its base forms.
-                    int formsCount = 0;
-
-                    finalStatesIterator.RestartFrom(fsa.GetEndNode(arc));
-                    while (finalStatesIterator.MoveNext())
-                    {
-                        ByteBuffer bb = finalStatesIterator.Current;
-                        byte[] ba = bb.Array;
-                        int bbSize = bb.Remaining;
-
-                        if (formsCount >= forms.Length)
-                        {
-                            //forms = Arrays.CopyOf(forms, forms.Length + EXPAND_SIZE);
-                            Array.Resize(ref forms, forms.Length + ExpandSize);
-                            for (int k = 0; k < forms.Length; k++)
-                            {
-                                if (forms[k] == null)
-                                    forms[k] = new WordData(decoder);
-                            }
-                        }
-
-                        /*
-                         * Now, expand the prefix/ suffix 'compression' and store
-                         * the base form.
-                         */
-                        WordData wordData = forms[formsCount++];
-                        if (!dictionaryMetadata.OutputConversionPairs.Any())
-                        {
-                            wordData.Update(byteBuffer, word);
-                        }
-                        else
-                        {
-                            wordData.Update(byteBuffer, ApplyReplacements(word, dictionaryMetadata.OutputConversionPairs));
-                        }
-
-                        /*
-                         * Find the separator byte's position splitting the inflection instructions
-                         * from the tag.
-                         */
-                        Debug.Assert(prefixBytes <= bbSize, sequenceEncoder.GetType() + " >? " + bbSize);
-                        int sepPos;
-                        for (sepPos = prefixBytes; sepPos < bbSize; sepPos++)
-                        {
-                            if (ba[sepPos] == separator)
-                            {
-                                break;
-                            }
-                        }
-
-                        /*
-                         * Decode the stem into stem buffer.
-                         */
-                        wordData.stemBuffer = sequenceEncoder.Decode(wordData.stemBuffer,
-                                                                 byteBuffer,
-                                                                 ByteBuffer.Wrap(ba, 0, sepPos));
-
-                        // Skip separator character.
-                        sepPos++;
-
-                        /*
-                         * Decode the tag data.
-                         */
-                        int tagSize = bbSize - sepPos;
-                        if (tagSize > 0)
-                        {
-                            wordData.tagBuffer = BufferUtils.ClearAndEnsureCapacity(wordData.tagBuffer, tagSize);
-                            wordData.tagBuffer.Put(ba, sepPos, tagSize);
-                            wordData.tagBuffer.Flip();
-                        }
-                    }
-
-                    formsList.Wrap(forms, 0, formsCount);
-                }
-            }
-            else
-            {
-                /*
-                 * this case is somewhat confusing: we should have hit the separator
-                 * first... I don't really know how to deal with it at the time
-                 * being.
-                 */
-            }
-            return formsList;
+            return Lookup(wordBuffer);
         }
 
         /// <summary>

--- a/src/Morfologik.Stemming/WordData.cs
+++ b/src/Morfologik.Stemming/WordData.cs
@@ -104,10 +104,9 @@ namespace Morfologik.Stemming
         public ByteBuffer GetStemBytes(ByteBuffer? target)
         {
             target = BufferUtils.ClearAndEnsureCapacity(target, stemBuffer.Remaining);
-            stemBuffer.Mark();
-            target.Put(stemBuffer);
-            stemBuffer.Reset();
+            target.Put(stemBuffer.Array, stemBuffer.Position, stemBuffer.Remaining);
             target.Flip();
+
             return target;
         }
 
@@ -124,10 +123,9 @@ namespace Morfologik.Stemming
         public ByteBuffer GetTagBytes(ByteBuffer? target)
         {
             target = BufferUtils.ClearAndEnsureCapacity(target, tagBuffer.Remaining);
-            tagBuffer.Mark();
-            target.Put(tagBuffer);
-            tagBuffer.Reset();
+            target.Put(tagBuffer.Array, tagBuffer.Position, tagBuffer.Remaining);
             target.Flip();
+
             return target;
         }
 
@@ -149,10 +147,9 @@ namespace Morfologik.Stemming
                 throw new InvalidOperationException("wordBuffer must be set prior to calling GetWordBytes(ByteBuffer)");
 
             target = BufferUtils.ClearAndEnsureCapacity(target, wordBuffer.Remaining);
-            wordBuffer.Mark();
-            target.Put(wordBuffer);
-            wordBuffer.Reset();
+            target.Put(wordBuffer.Array, wordBuffer.Position, wordBuffer.Remaining);
             target.Flip();
+
             return target;
         }
 
@@ -162,10 +159,8 @@ namespace Morfologik.Stemming
         /// </summary>
         public ICharSequence? GetTag()
         {
-            //decoder.GetChars(tagBuffer, 0, tagBuffer.Length, tagCharSequence, 0);
-            //return tagCharSequence.Length == 0 ? null : new string(tagCharSequence);
             tagCharSequence = BufferUtils.BytesToChars(decoder, tagBuffer, tagCharSequence);
-            return tagCharSequence.Length == 0 ? null : tagCharSequence.ToString().AsCharSequence();
+            return tagCharSequence.Length == 0 ? null : tagCharSequence;
         }
 
         /// <summary>
@@ -174,11 +169,8 @@ namespace Morfologik.Stemming
         /// </summary>
         public ICharSequence? GetStem()
         {
-            //decoder.GetChars(stemBuffer, 0, stemBuffer.Length, stemCharSequence, 0);
-            //return stemCharSequence.Length == 0 ? null : new string(stemCharSequence);
-
             stemCharSequence = BufferUtils.BytesToChars(decoder, stemBuffer, stemCharSequence);
-            return stemCharSequence.Length == 0 ? null : stemCharSequence.ToString().AsCharSequence();
+            return stemCharSequence.Length == 0 ? null : stemCharSequence;
         }
 
         /// <summary>
@@ -249,11 +241,5 @@ namespace Morfologik.Stemming
             this.wordBuffer = wordBuffer;
             this.wordCharSequence = word;
         }
-
-        internal void Update(ByteBuffer wordBuffer, char[] word) => Update(wordBuffer, word.AsCharSequence());
-
-        internal void Update(ByteBuffer wordBuffer, StringBuilder word) => Update(wordBuffer, word.AsCharSequence());
-
-        internal void Update(ByteBuffer wordBuffer, string word) => Update(wordBuffer, word.AsCharSequence());
     }
 }

--- a/tests/Morfologik.Polish.Tests/PolishMorfologikStemmerTest.cs
+++ b/tests/Morfologik.Polish.Tests/PolishMorfologikStemmerTest.cs
@@ -64,7 +64,7 @@ namespace Morfologik.Stemming.Polish.Tests
             {
                 stems.Add(wd.GetStem().ToString());
                 tags.Add(wd.GetTag().ToString());
-                assertSame(word, wd.Word.ToString());
+                assertEquals(word, wd.Word.ToString());
             }
             assertTrue(stems.Contains("ligać"));
             assertTrue(stems.Contains("liga"));


### PR DESCRIPTION
Those changes make dictionary lookups allocation free for all Lookup overloads, by introducing two additional helper buffers within DictionaryLookup class and by  optimizing BufferUtils and WordData implementations.

The only breaking change is withing Polish stemmer tests, where resulting value is not the same instance, but it is still equal.